### PR TITLE
fix: handle null connection id

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ export const App: React.FC = () => {
     }
 
     const handleConnectOtherPeer = () => {
-        dispatch(connectionAction.connectPeer(connection.id || ''))
+        connection.id != null ? dispatch(connectionAction.connectPeer(connection.id || "")) : message.warning("Please enter ID")
     }
 
     const [fileList, setFileList] = useAsyncState([] as UploadFile[])
@@ -99,7 +99,9 @@ export const App: React.FC = () => {
                             <Card>
                                 <Space direction="horizontal">
                                     <Input placeholder={"ID"}
-                                           onChange={e => dispatch(connectionAction.changeConnectionInput(e.target.value))}/>
+                                           onChange={e => dispatch(connectionAction.changeConnectionInput(e.target.value))}
+                                           required={true}
+                                           />
                                     <Button onClick={handleConnectOtherPeer}
                                             loading={connection.loading}>Connect</Button>
                                 </Space>


### PR DESCRIPTION
> Bug I find is that when user click on connect without enter the peer id process getting stuck in infinite connection loading,
> So I have simply add one null check.
> 

possible solution:
`
connection.id != null ? dispatch(connectionAction.connectPeer(connection.id || "")) : message.warning("Please enter ID")
`